### PR TITLE
Fixed blob to HTML conversion and added rendering hook.

### DIFF
--- a/http/term_html.pl
+++ b/http/term_html.pl
@@ -70,6 +70,11 @@ any(_, Options) -->
 	{ Options.depth >= Options.max_depth }, !,
 	html(span(class('pl-ellipsis'), ...)).
 any(Term, Options) -->
+   { blob(Term,Type) }, !, 
+   (  pengines_io:blob_rendering(Type,Term,Options) -> []
+   ;  html(span(class('pl-blob'),Type))
+   ).
+any(Term, Options) -->
 	{ primitive(Term, Class0), !,
 	  quote_atomic(Term, S, Options),
 	  primitive_class(Class0, Term, S, Class)

--- a/pengines_io.pl
+++ b/pengines_io.pl
@@ -446,6 +446,17 @@ term_html_string(Term, Vars, Module, HTMLString) :-
 
 :- multifile binding_term//3.
 
+%% blob_rendering(+BlobType, +Blob, +WriteOptions)// is semidet.
+%
+%  Hook to render blob atoms as HTML. This hook is called whenever
+%  a blob atom is encountered while rendering a compound term as HTML.
+%  The blob type is provided to allow efficient indexing without
+%  having to examine the blob. If this predicate fails, the blob
+%  is rendered as an HTML SPAN with class 'pl-blob' containing  
+%  BlobType as text.
+
+:- multifile blob_rendering//3.
+
 term_html(Term, Vars, WriteOptions) -->
 	{ nonvar(Term) },
 	binding_term(Term, Vars, WriteOptions), !.

--- a/web/css/plterm.css
+++ b/web/css/plterm.css
@@ -18,6 +18,13 @@ span.pl-dict		{}
 span.pl-key		{font-weight:bold;}
 span.pl-constraint	{color:#008b8b;}
 span.pl-comment		{color: #060; font-style: italic;}
+span.pl-blob { 
+   border-radius: 1em;
+   background-color: #444; 
+   margin: 0.1ex;
+   padding: 0ex .5ex 0.2ex 0.5ex;
+   color:#fff 
+}
 
 /* pengines_io elements */
 


### PR DESCRIPTION
The problem was that term_html:term//3 was producing an assertion failure on line 88 when asked to render a term containing blobs, beause primitive/2 was not catching the blobs.

The changes are self-explanatory, I think -- the only question is which module to declare the blob_rendering//3 hook. I put it in pengines_io because there was already a hook there, but perhaps it should be in term_html.pl so as not to depend on pengines_io.pl. In fact, this version might not work correctly because pengines_io is not imported into term_html, so term_html does not know that pengines_io:blob_rendering//3 is multifile. Thus, if external code declares clauses of blob_rendering//3, they might clash or overwrite each other -- my understanding of multifile predicates leaves me unsure, so please feel free to re-organise the hook predicates as you see fit.
