### PR TITLE
Easy js include

### DIFF
--- a/pendoc.md
+++ b/pendoc.md
@@ -127,7 +127,7 @@ pengine_ask/3 with the option template(X) would instead produce the output
 
 main :-
     pengine_create([
-        server('http://pengines.org'),
+        server('http://pengines.swi-prolog.org'),
         src_text("
             q(X) :- p(X).
             p(a). p(b). p(c).
@@ -137,8 +137,8 @@ main :-
 
 
 handle(create(ID, _)) :-
-    pengine_ask(ID, q(X), []).
-handle(success(ID, [X], false)) :-
+    pengine_ask(ID, q(_X), []).
+handle(success(_ID, [X], false)) :-
     writeln(X).
 handle(success(ID, [X], true)) :-
     writeln(X),

--- a/pengines.pl
+++ b/pengines.pl
@@ -61,6 +61,7 @@ from Prolog or JavaScript.
 @author Torbjörn Lager and Jan Wielemaker
 */
 
+:- use_module(library(http/html_head)).
 :- use_module(library(http/http_dispatch)).
 :- use_module(library(http/http_parameters)).
 :- use_module(library(http/http_json)).
@@ -88,6 +89,12 @@ from Prolog or JavaScript.
 :- use_module(library(uuid)).
 :- endif.
 
+:- dynamic(user:file_search_path/2).
+:- multifile(user:file_search_path/2).
+
+user:file_search_path(js, 'web/js').
+
+:- html_resource(js(pengines), [requires([js('pengines.js')]),virtual(true)]).
 
 :- meta_predicate
 	pengine_create(:),

--- a/pengines.pl
+++ b/pengines.pl
@@ -634,7 +634,7 @@ pengine_uuid(Id) :-
 
 /** pengine_application(+Application) is det.
 
-Directive that must be used to declarate  a pengine application
+Directive that must be used to declare  a pengine application
 module. The module may not  be  associated   to  any  file.  The default
 application is =pengine_sandbox=.  The  example   below  creates  a  new
 application =address_book= and imports the  API   defined  in the module


### PR DESCRIPTION
Besides improving the documentation a bit, this allows Web applications to include Pengine JS code by using `\html_requires(js(pengines))`.

Currently people are copying the `pengines.js` into each project (duplication) and fixes in swipl-devel require these local files to be replaced.