### PR TITLE
Remove SSU rule from findnsols_no_empty

### DIFF
--- a/pengines.pl
+++ b/pengines.pl
@@ -1419,10 +1419,10 @@ filter_template(Template0, Bindings, Template) :-
     dict_create(Template, swish_default_template, Bindings).
 filter_template(Template, _Bindings, Template).
 
-findnsols_no_empty(no_chunk, Template, Goal, [Template]) =>
+findnsols_no_empty(no_chunk, Template, Goal, [Template]) :-
     call(Goal).
-findnsols_no_empty(State, Template, Goal, List) =>
-    findnsols(State, Template, Goal, List),
+findnsols_no_empty(count(N), Template, Goal, List) :-
+    findnsols(count(N), Template, Goal, List),
     List \== [].
 
 destroy_or_continue(Event) :-


### PR DESCRIPTION
In the current version of the code, the first rule (no_chunk) never matches, because `[Template]` is unified in the head. While it is possible to just write the head as

```
findnsols_no_empty(no_chunk, Template, Goal, L) =>
```

and do the unification later, I think a better solution is not using SSU rules, since the two clauses can be always distinguished by their first argument (no_chunk vs count(N)).

This PR fixes this behavior and makes the recursive toplevel in pengines work as intended with `chunk=false`.